### PR TITLE
Fix numbered bibliography generation of asciidoctor-bib

### DIFF
--- a/lib/asciidoc-bib/asciidoctor.rb
+++ b/lib/asciidoc-bib/asciidoctor.rb
@@ -46,7 +46,6 @@ module AsciidocBib
             processor.sorted_cites.reverse.each do |ref|
               lines.insert biblio_index, "\n"
               lines.insert biblio_index, processor.get_reference(ref)
-              lines.insert biblio_index, "\n"
               lines.insert biblio_index, "[normal]\n" # ? needed to force paragraph breaks
             end
           end


### PR DESCRIPTION
asciidoctor-bib failed to generate a numbered reference list for numeric style, such as ieee style. This can be verified by running `asciidoctor-bib -s ieee sample-1.txt`.

Investigation into the source code shows that the asciidoctor preprocessor inserts `[normal] \n . #{REF} \n` for a reference item. The first `\n` breaks the lists. This patch fixes that by simply removing the extra `\n`.

asciidoc-bib is correct in all cases.  